### PR TITLE
Allow to start server with 'python -m hamms'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Or clone this project:
 
 1. Start hamms by running it from the command line:
 
-        python hamms/__init__.py
+        python -m hamms
 
     Or use the HammsServer class to start and stop the server on command.
 

--- a/hamms/__init__.py
+++ b/hamms/__init__.py
@@ -371,7 +371,12 @@ reactor.listenTCP(large_header_app.PORT, large_header_site)
 reactor.listenTCP(retries_app.PORT, retries_site)
 reactor.listenTCP(DropRandomRequestsServer.PORT, DropRandomRequestsFactory())
 
-if __name__ == "__main__":
+
+def main():
     logging.basicConfig()
     logger.info("Listening...")
     reactor.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/hamms/__main__.py
+++ b/hamms/__main__.py
@@ -1,0 +1,5 @@
+from hamms import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is more "pythonic" way of running packages.

It should also be easier to add options to this command in future (using optparse or argparse)
as we already have designated module for command handling.
