### PR TITLE
Allow to install in development mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='hamms',


### PR DESCRIPTION
User can now install with python setup.py develop

This makes developing the package easier, I'm just not sure if you wan't to require `setuptools` at this point.
